### PR TITLE
GNU cp command support for Mac

### DIFF
--- a/makexpi.sh
+++ b/makexpi.sh
@@ -146,7 +146,7 @@ rm -f ${appname}${suffix}-*.lzh
 mkdir -p xpi_temp
 
 for f in ${xpi_contents}; do
-        $cp -rp --parents ${f} xpi_temp/
+	$cp -rp --parents ${f} xpi_temp/
 done
 
 $cp -r content ./xpi_temp/


### PR DESCRIPTION
cp command in mac platform is not GNU's cp command.
We can install GNU cp command (gcp) via Macports or Homebrew.
