### PR TITLE
Use gsha1sum command instead of sha1sum command in OS X

### DIFF
--- a/makexpi.sh
+++ b/makexpi.sh
@@ -65,6 +65,11 @@ case $(uname) in
   *)                   cp="cp" ;;
 esac
 
+case $(uname) in
+  Darwin|*BSD) sha1sum="gsha1sum" ;;
+  *)           sha1sum="sha1sum" ;;
+esac
+
 use_version=0
 nojar=0
 xpi_compression_level=9
@@ -281,6 +286,6 @@ cd ..
 rm -r -f xpi_temp
 
 # create hash
-sha1sum -b ${appname}*.xpi > sha1hash.txt
+$sha1sum -b ${appname}*.xpi > sha1hash.txt
 
 exit 0;


### PR DESCRIPTION
In OS X, it can install GNU `sha1sum` command via Homebrew or Macports.
As usual, GNU toolchain command name is added 'g' prefix in OS X and *BSD.

In sha1sum case, command name is `gsha1sum`.
