### PR TITLE
Fix getopts

### DIFF
--- a/prepare_build_scripts.sh
+++ b/prepare_build_scripts.sh
@@ -8,7 +8,7 @@ case $(uname) in
   *)                   sed="sed -r" ;;
 esac
 
-while getopts t:p:o:k:s:e: OPT
+while getopts n: OPT
 do
   case $OPT in
     "n" ) name="$OPTARG" ;;


### PR DESCRIPTION
I tried to build firefox addons, but specification of prepare_build_scripts.sh is different from documents description.
I think getopts is incorrect.

```
$ git clone https://github.com/piroor/makexpi
$ makexpi/prepare_build_scripts.sh -n "force-addon-status"
makexpi/prepare_build_scripts.sh: 不正なオプションです -- n
Input the name of the package>
```